### PR TITLE
stop using aliased parameters, to fix #5

### DIFF
--- a/t/lib/App/Rssfilter/Group/Test/AddedGroup.pm
+++ b/t/lib/App/Rssfilter/Group/Test/AddedGroup.pm
@@ -11,8 +11,8 @@ use namespace::autoclean;
 requires 'group';
 requires 'mock_group';
 
-method count_matches( $needle, \@haystack ) {
-    return grep { $needle eq $_ } @haystack;
+method count_matches( $needle, ArrayRef $haystack ) {
+    return grep { $needle eq $_ } @{ $haystack };
 }
 
 method count_mock_group_matches() {


### PR DESCRIPTION
Since 2013-10-10, t/app/rssfilter/group/group.t has been failing due to

```
Can't located Data/Alias in @INC (@INC contains: ... ) at /home/dgh/.perlbrew/libs/perl-5.16.1/lib/perl5/Method/Signatures.pm line 1121
```

Release 20131010 of Method::Signatures changed Data::Alias from a prerequisite to a recommended, and thus consumers should require it themselves.

I've removed the reliance on aliased parameters which causes M::S to require D::A.
